### PR TITLE
Rework Contexts

### DIFF
--- a/src/front/apps/fl-dashboard/currently-viewing/index.js
+++ b/src/front/apps/fl-dashboard/currently-viewing/index.js
@@ -1,5 +1,12 @@
 import React, { useContext } from 'react'
-import { ActionGroup, VerticalGroup, HorizontalGroup, ExpandedContents, PageViewContext } from 'components'
+import {
+	ActionGroup,
+	VerticalGroup,
+	HorizontalGroup,
+	ExpandedContents,
+	PageViewContext
+} from 'components'
+
 import './style.scss'
 
 export const CurrentlyViewing = () => {

--- a/src/front/apps/fl-dashboard/currently-viewing/index.js
+++ b/src/front/apps/fl-dashboard/currently-viewing/index.js
@@ -1,11 +1,9 @@
-import React from 'react'
-import { useStore } from 'store'
-import { ActionGroup, VerticalGroup, HorizontalGroup, ExpandedContents } from 'components'
+import React, { useContext } from 'react'
+import { ActionGroup, VerticalGroup, HorizontalGroup, ExpandedContents, PageViewContext } from 'components'
 import './style.scss'
 
 export const CurrentlyViewing = () => {
-	const { currentPageView } = useStore()
-	const { intro, name, theme, actions } = currentPageView
+	const { intro, name, theme, actions } = useContext( PageViewContext )
 
 	return (
 		<div className="fl-asst-currently-viewing">

--- a/src/front/apps/fl-dashboard/index.js
+++ b/src/front/apps/fl-dashboard/index.js
@@ -7,6 +7,8 @@ import { useStore } from 'store'
 export const DashboardTab = () => {
 	const { currentUser, dashboardApp } = useStore()
 	const { togglePanelPosition } = useContext( UIContext )
+
+	// @TODO: Rename dashboardApp and move into app state
 	const { adminActions } = dashboardApp
 
 	return (

--- a/src/front/apps/fl-dashboard/recently-edited/index.js
+++ b/src/front/apps/fl-dashboard/recently-edited/index.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import classname from 'classnames'
 import { Widget, Tag, TagGroup, ContentQuery } from 'components'
 import { useAppState } from 'store'
 

--- a/src/front/apps/fl-testing.js
+++ b/src/front/apps/fl-testing.js
@@ -1,34 +1,30 @@
 import React, { useContext } from 'react'
 import { useDispatch } from 'store'
-import { Button, ScreenHeader, StackContext, AppContext, UIContext } from 'components'
+import { Button, ScreenHeader, StackContext } from 'components'
 
 const { registerApp } = useDispatch()
 
 const DetailScreen = () => {
-    const context = useContext( StackContext )
-    return (
-        <div>
-            <ScreenHeader title="Detail Screen" />
-            <Button onClick={ () => {} }>Pop View</Button>
-        </div>
-    )
+	const { popView } = useContext( StackContext )
+	return (
+		<div>
+			<ScreenHeader title="Detail Screen" />
+			<Button onClick={popView}>Pop View</Button>
+		</div>
+	)
 }
 
 const MainScreen = () => {
-    const ui = useContext( UIContext )
-    const app = useContext( AppContext )
-    const stack = useContext( StackContext )
-    console.log('fl-testing', { ui, app, stack })
-    return (
-        <div>
-            <ScreenHeader />
-
-            <Button onClick={ () => {} }>Push View</Button>
-        </div>
-    )
+	const { pushView } = useContext( StackContext )
+	return (
+		<div>
+			<ScreenHeader />
+			<Button onClick={ () => pushView( <DetailScreen /> ) }>Push View</Button>
+		</div>
+	)
 }
 
 registerApp( 'fl-testing', {
-	label: 'Test',
+	label: 'Testing Screen',
 	content: props => <MainScreen {...props} />,
 } )

--- a/src/front/apps/fl-testing.js
+++ b/src/front/apps/fl-testing.js
@@ -1,0 +1,31 @@
+import React, { useContext } from 'react'
+import { useDispatch } from 'store'
+import { Button, ScreenHeader, StackContext, AppContext, UIContext } from 'components'
+
+const { registerApp } = useDispatch()
+
+const DetailScreen = () => {
+    const context = useContext( StackContext )
+    return (
+        <div>
+            <ScreenHeader title="Detail Screen" />
+            <Button onClick={ () => {} }>Pop View</Button>
+        </div>
+    )
+}
+
+registerApp( 'fl-testing', {
+	label: 'Test',
+	content: props => {
+        const ui = useContext( UIContext )
+        const app = useContext( AppContext )
+        const stack = useContext( StackContext )
+		return (
+			<div>
+                <ScreenHeader />
+
+                <Button onClick={ () => {} }>Push View</Button>
+			</div>
+		)
+	},
+} )

--- a/src/front/apps/fl-testing.js
+++ b/src/front/apps/fl-testing.js
@@ -14,18 +14,21 @@ const DetailScreen = () => {
     )
 }
 
+const MainScreen = () => {
+    const ui = useContext( UIContext )
+    const app = useContext( AppContext )
+    const stack = useContext( StackContext )
+    console.log('fl-testing', { ui, app, stack })
+    return (
+        <div>
+            <ScreenHeader />
+
+            <Button onClick={ () => {} }>Push View</Button>
+        </div>
+    )
+}
+
 registerApp( 'fl-testing', {
 	label: 'Test',
-	content: props => {
-        const ui = useContext( UIContext )
-        const app = useContext( AppContext )
-        const stack = useContext( StackContext )
-		return (
-			<div>
-                <ScreenHeader />
-
-                <Button onClick={ () => {} }>Push View</Button>
-			</div>
-		)
-	},
+	content: props => <MainScreen {...props} />,
 } )

--- a/src/front/apps/index.js
+++ b/src/front/apps/index.js
@@ -7,9 +7,6 @@ import { FindTab, FindIcon } from './fl-find'
 import { NotificationsTab, NotificationsIcon } from './fl-notifications'
 import { MediaTab, MediaIcon } from './fl-media'
 
-// Test screen
-import './fl-testing'
-
 const { registerApp } = useDispatch()
 
 registerApp( 'fl-notifications', {

--- a/src/front/apps/index.js
+++ b/src/front/apps/index.js
@@ -7,6 +7,9 @@ import { FindTab, FindIcon } from './fl-find'
 import { NotificationsTab, NotificationsIcon } from './fl-notifications'
 import { MediaTab, MediaIcon } from './fl-media'
 
+// Test screen
+import './fl-testing'
+
 const { registerApp } = useDispatch()
 
 registerApp( 'fl-notifications', {

--- a/src/front/index.js
+++ b/src/front/index.js
@@ -2,7 +2,7 @@ import React, { StrictMode } from 'react'
 import { render } from 'react-dom'
 import { Provider } from 'react-redux'
 import { UI, ShowUITrigger } from './ui'
-import { UIContext } from 'components'
+import { UIContext, PageViewContext } from 'components'
 import store, { useStore, useDispatch } from 'store'
 import './api'
 import './apps'
@@ -11,12 +11,13 @@ import './apps'
  * The Root Component
  */
 const App = () => {
-	const { isShowingUI, activeApp, panelPosition } = useStore()
+	const { isShowingUI, activeApp, panelPosition, currentPageView } = useStore()
 	const { setIsShowingUI, setActiveApp, togglePanelPosition, setPanelPosition } = useDispatch()
 
 	// Create a toggle function to show/hide the panel
 	const toggleIsShowingUI = () => isShowingUI ? setIsShowingUI( false ) : setIsShowingUI( true )
 
+	// Create a store-bound value object for UIContext.Provider
 	const ui = {
 		isShowingUI,
 		setIsShowingUI,
@@ -32,11 +33,13 @@ const App = () => {
 		<StrictMode>
 			<Provider store={store}>
 				<UIContext.Provider value={ui}>
-					{/* This is the button that toggles the UI panel */}
-					<ShowUITrigger />
+					<PageViewContext.Provider value={currentPageView}>
+						{/* This is the button that toggles the UI panel */}
+						{ !isShowingUI && <ShowUITrigger /> }
 
-					{/* This is the panel itself */}
-					<UI />
+						{/* This is the panel itself */}
+						<UI />
+					</PageViewContext.Provider>
 				</UIContext.Provider>
 			</Provider>
 		</StrictMode>

--- a/src/front/index.js
+++ b/src/front/index.js
@@ -35,7 +35,7 @@ const App = () => {
 				<UIContext.Provider value={ui}>
 					<PageViewContext.Provider value={currentPageView}>
 						{/* This is the button that toggles the UI panel */}
-						{ !isShowingUI && <ShowUITrigger /> }
+						{ ! isShowingUI && <ShowUITrigger /> }
 
 						{/* This is the panel itself */}
 						<UI />

--- a/src/front/store/index.js
+++ b/src/front/store/index.js
@@ -3,7 +3,7 @@ import { createStore, applyMiddleware, bindActionCreators } from 'redux'
 import { applyEffects, composeEnhancers } from './middleware'
 import reducers from './reducers'
 import * as actions from './actions'
-import { CurrentTabContext } from 'components'
+import { AppContext } from 'components'
 
 
 const store = createStore( reducers, {
@@ -27,7 +27,7 @@ export const useDispatch = () => {
 
 export const useAppState = ( key, value ) => {
 	const { appState } = store.getState()
-	const { app } = useContext( CurrentTabContext )
+	const { app } = useContext( AppContext )
 	const [ state, setState ] = useState(
 		appState[ app ] && appState[ app ][ key ] ? appState[ app ][ key ] : value
 	)

--- a/src/front/ui/components/content-list/parts.js
+++ b/src/front/ui/components/content-list/parts.js
@@ -10,7 +10,6 @@ export const ContentListContainer = ( { className, children } ) => {
 
 export const ContentListItem = ( {
 	url = null,
-	edit_url = null,
 	thumbnail = null,
 	title = '',
 	author = '',

--- a/src/front/ui/components/contexts/index.js
+++ b/src/front/ui/components/contexts/index.js
@@ -6,7 +6,7 @@ UIContext.displayName = 'UIContext'
 export const AppContext = createContext()
 AppContext.displayName = 'AppContext'
 
-export const StackContext = createContext('test')
+export const StackContext = createContext()
 StackContext.displayName = 'StackContext'
 
 export const PageViewContext = createContext()

--- a/src/front/ui/components/contexts/index.js
+++ b/src/front/ui/components/contexts/index.js
@@ -1,10 +1,13 @@
 import { createContext } from 'react'
 
-export const CurrentPageViewContext = createContext( FLAssistantInitialData.currentPageView )
-CurrentPageViewContext.displayName = 'CurrentPageViewContext'
-
-export const CurrentTabContext = createContext()
-CurrentTabContext.displayName = 'CurrentTabContext'
-
 export const UIContext = createContext()
 UIContext.displayName = 'UIContext'
+
+export const AppContext = createContext()
+AppContext.displayName = 'AppContext'
+
+export const StackContext = createContext('test')
+StackContext.displayName = 'StackContext'
+
+export const PageViewContext = createContext()
+PageViewContext.displayName = 'PageViewContext'

--- a/src/front/ui/components/index.js
+++ b/src/front/ui/components/index.js
@@ -13,17 +13,24 @@ export {
 } from './layout-helpers'
 
 export { TagGroup, Tag, TagGroupControl, ActionGroup } from './tag-groups'
+
 export {
 	PanelChrome,
 	PanelFrame,
 	ScreenHeader,
 	ScreenFooter,
 	ExpandedContents,
-	EmptyMessage
+	EmptyMessage,
 } from './panel-parts'
 
-export { CurrentPageViewContext, CurrentTabContext, UIContext } from './contexts'
+export {
+	PageViewContext,
+	UIContext,
+	AppContext,
+	StackContext,
+} from './contexts'
+
 export { ContentList, ContentQuery } from './content-list'
 export { Widget } from './widgets'
-export { Stack, StackContext } from './stacks'
-export { Tab, TabManager } from './tabs'
+export { Stack } from './stacks'
+export { Tab } from './tabs'

--- a/src/front/ui/components/panel-parts/index.js
+++ b/src/front/ui/components/panel-parts/index.js
@@ -1,6 +1,6 @@
 import React, { useContext, useState } from 'react'
 import classname from 'classnames'
-import { Button, AppTabButton, Icon, CurrentTabContext } from 'components'
+import { Button, AppTabButton, Icon, AppContext } from 'components'
 import { NotificationsIcon } from 'apps/fl-notifications'
 import './style.scss'
 
@@ -77,7 +77,7 @@ export const PanelChrome = ( { tabs, activeTabName, onTabClick, onClose } ) => {
 }
 
 export const ScreenHeader = ( { children, showTitle, title } ) => {
-	const tab = useContext( CurrentTabContext )
+	const tab = useContext( AppContext )
 	const screenTitle = title ? title : tab.label
 	return (
 		<div className="fl-asst-screen-header">

--- a/src/front/ui/components/stacks/index.js
+++ b/src/front/ui/components/stacks/index.js
@@ -1,22 +1,23 @@
-import React, { createContext, useState } from 'react'
+import React from 'react'
 import classname from 'classnames'
 import { StackContext } from 'components'
 import './style.scss'
 
 export const Stack = ( { children, className } ) => {
-	const [stack, setStack] = useState([])
+
 	const classes = classname( {
 		'fl-asst-view-stack': true,
 	}, className )
 
 	const context = {
-		pushView: component => {
-			console.log('push', component)
-			const newStack = stack
+		pushView: () => {
+
+			//console.log( 'push', component )
 
 		},
 		popView: () => {
-			console.log('pop')
+
+			//console.log( 'pop' )
 		},
 	}
 

--- a/src/front/ui/components/stacks/index.js
+++ b/src/front/ui/components/stacks/index.js
@@ -1,18 +1,23 @@
-import React, { createContext } from 'react'
+import React, { createContext, useState } from 'react'
 import classname from 'classnames'
+import { StackContext } from 'components'
 import './style.scss'
 
-export const StackContext = createContext()
-StackContext.displayName = 'StackContext'
-
-export const Stack = ( { children } ) => {
+export const Stack = ( { children, className } ) => {
+	const [stack, setStack] = useState([])
 	const classes = classname( {
 		'fl-asst-view-stack': true,
-	} )
+	}, className )
 
 	const context = {
-		pushView: component => {},
-		popView: () => {},
+		pushView: component => {
+			console.log('push', component)
+			const newStack = stack
+
+		},
+		popView: () => {
+			console.log('pop')
+		},
 	}
 
 	return (

--- a/src/front/ui/components/tabs.js
+++ b/src/front/ui/components/tabs.js
@@ -1,19 +1,7 @@
 import React from 'react'
-import { Stack } from 'components'
-
-export const TabManager = ( { activeTabName, children } ) => {
-	return React.Children.map( children, child => {
-		const isSelected = child.props.name === activeTabName ? true : false
-		return React.cloneElement( child, { isSelected: isSelected } )
-	} )
-}
 
 export const Tab = ( { children, isSelected } ) => {
 	return (
-		<div className="fl-asst-tab" hidden={ ! isSelected }>
-			<Stack>
-				{children}
-			</Stack>
-		</div>
+		<div className="fl-asst-tab" hidden={ ! isSelected }>{children}</div>
 	)
 }

--- a/src/front/ui/index.js
+++ b/src/front/ui/index.js
@@ -49,7 +49,6 @@ export const UI = () => {
 							<AppContext.Provider key={key} value={app}>
 								<Tab name={key} isSelected={app.isActive}>
 									<Stack>
-									{ console.log(key, stack )}
 									{ app.content() }
 									</Stack>
 								</Tab>

--- a/src/front/ui/index.js
+++ b/src/front/ui/index.js
@@ -4,11 +4,13 @@ import {
 	Icon,
 	Separator,
 	Tab,
-	TabManager,
-	CurrentTabContext,
 	PanelFrame,
 	PanelChrome,
-	UIContext
+
+	Stack,
+	AppContext,
+	UIContext,
+	StackContext,
 } from 'components'
 
 import { useStore, useDispatch } from 'store'
@@ -26,6 +28,8 @@ export const UI = () => {
 		return null
 	}
 
+	const stack = useContext( StackContext )
+
 	return (
 		<PanelFrame position={panelPosition}>
 			<div className="fl-asst-panel-wrap">
@@ -38,18 +42,20 @@ export const UI = () => {
 				<Separator isSlim={true} />
 
 				<div className="fl-asst-panel-contents">
-					<TabManager activeTabName={activeApp}>
-						{Object.keys( apps ).map( key => {
-							const tab = apps[key]
-							return (
-								<Tab key={key} name={key}>
-									<CurrentTabContext.Provider value={tab}>
-										{tab.content()}
-									</CurrentTabContext.Provider>
+					{Object.keys( apps ).map( ( key, i ) => {
+						const app = apps[key]
+						app.isActive = app.app === activeApp ? true : false
+						return (
+							<AppContext.Provider key={key} value={app}>
+								<Tab name={key} isSelected={app.isActive}>
+									<Stack>
+									{ console.log(key, stack )}
+									{ app.content() }
+									</Stack>
 								</Tab>
-							)
-						} )}
-					</TabManager>
+							</AppContext.Provider>
+						)
+					} )}
 				</div>
 			</div>
 		</PanelFrame>

--- a/src/front/ui/index.js
+++ b/src/front/ui/index.js
@@ -6,11 +6,9 @@ import {
 	Tab,
 	PanelFrame,
 	PanelChrome,
-
 	Stack,
 	AppContext,
 	UIContext,
-	StackContext,
 } from 'components'
 
 import { useStore, useDispatch } from 'store'
@@ -28,8 +26,6 @@ export const UI = () => {
 		return null
 	}
 
-	const stack = useContext( StackContext )
-
 	return (
 		<PanelFrame position={panelPosition}>
 			<div className="fl-asst-panel-wrap">
@@ -42,14 +38,14 @@ export const UI = () => {
 				<Separator isSlim={true} />
 
 				<div className="fl-asst-panel-contents">
-					{Object.keys( apps ).map( ( key, i ) => {
+					{Object.keys( apps ).map( key => {
 						const app = apps[key]
 						app.isActive = app.app === activeApp ? true : false
 						return (
 							<AppContext.Provider key={key} value={app}>
 								<Tab name={key} isSelected={app.isActive}>
 									<Stack>
-									{ app.content() }
+										{ app.content() }
 									</Stack>
 								</Tab>
 							</AppContext.Provider>


### PR DESCRIPTION
This is a restructuring of the four available contexts: `UIContext`, `AppContext`, `PageViewContext` and `StackContext`(WIP). These can be accessed from within any app screen. Note: passing a function that returns DOM elements directly as the `content` key for your app will result in `AppContext` and `StackContext` resolving to `undefined`. Your app should have a React component at its root, not simply a DOM element if you want to use either of those contexts. I maybe be adding something in the future to cause this not to be a factor, but for now that's the way it is.