### PR TITLE
Fix unreachable system api

### DIFF
--- a/backend/src/Hooks/Filters/OnScriptLoaderTag.php
+++ b/backend/src/Hooks/Filters/OnScriptLoaderTag.php
@@ -14,7 +14,6 @@ class OnScriptLoaderTag {
 	public function __invoke( $tag, $handle, $src ) {
 
 		$handles = [
-			'fl-assistant',
 			'fl-assistant-render',
 			'fl-assistant-apps'
 		];


### PR DESCRIPTION
The main system js file was being loaded as a module script making the `FL.Assistant` global API near impossible to use externally. This API needs to be available if you ever want to register an app from another plugin.

The render and apps bundles can still load as modules because they don't need to expose any public api.