### PR TITLE
Keep known private post types out of the cloud library upload picker

### DIFF
--- a/backend/src/Data/Repository/PostsRepository.php
+++ b/backend/src/Data/Repository/PostsRepository.php
@@ -147,6 +147,15 @@ class PostsRepository extends RepositoryAbstract {
 			'fl_code',
 		] );
 
+		// Of the types above, those whose items are portable enough to bulk add to a
+		// cloud library. Opt-in only: block templates are scoped to a theme via the
+		// wp_theme taxonomy and code snippets have their own library item type, so
+		// neither belongs in the upload picker. Design systems are portable by UUID,
+		// so they do.
+		$library = apply_filters( 'fl_assistant_post_types_library', [
+			'fl-design-system',
+		] );
+
 		// Types to never show
 		$ignore = [
 			'attachment',
@@ -175,7 +184,8 @@ class PostsRepository extends RepositoryAbstract {
 			}
 
 			$data[ $slug ] = [
-				'canView'        => $type->public || $type->publicly_queryable || in_array( $slug, $known ),
+				'canView'        => $type->public || $type->publicly_queryable || in_array( $slug, $library ),
+				'hasPublicUrl'   => $type->public || $type->publicly_queryable,
 				'canExport'      => $type->can_export,
 				'hasArchive'     => $type->has_archive,
 				'isHierarchical' => $type->hierarchical,

--- a/src/system/ui/notices/notice/style.scss
+++ b/src/system/ui/notices/notice/style.scss
@@ -8,6 +8,12 @@
         border-bottom: 1px solid var(--fluid-opaque-10);
         pointer-events: auto;
 
+        // Core renders .components-notice as a grid with align-items: start, which
+        // leaves the content hugging the top of our 60px bar, and rounds the corners
+        // of what should be a flat edge-to-edge notice.
+        align-items: center;
+        border-radius: 0;
+
         &.is-info {
             color: var(--fluid-primary-color);
             background: var(--fluid-primary-background);

--- a/src/system/ui/pages/code/location/rules.js
+++ b/src/system/ui/pages/code/location/rules.js
@@ -11,7 +11,7 @@ const Rules = ( { item, onChange } ) => {
 	const { contentTypes } = getSystemConfig()
 	const typesData = Object.entries( contentTypes )
 	const exclude_types = ['fl-builder-template', 'fl_code', 'fl-theme-layout']
-	const types = typesData.filter( t => true === t[1].canView && !exclude_types.includes( t[0] ) )
+	const types = typesData.filter( t => true === t[1].hasPublicUrl && !exclude_types.includes( t[0] ) )
 	const locations = '' !== item.locations ? ( Array.isArray( item.locations ) ? item.locations : Object.values(item.locations) ) : [{
 		type: '',
 		operator: '',

--- a/src/system/ui/pages/post/actions.js
+++ b/src/system/ui/pages/post/actions.js
@@ -89,7 +89,10 @@ export const getPostActions = ( { history, values, setValue, createNotice, Cloud
 		{
 			label: contentTypes[type].labels.viewItem,
 			href: url,
-			shouldRender: contentTypes[type].canView
+
+			// Types can be listed in Assistant without having a front-end permalink,
+			// so gate the View action on hasPublicUrl rather than canView.
+			shouldRender: contentTypes[type].hasPublicUrl
 		},
 		{
 			label: __( 'Edit in Admin' ),


### PR DESCRIPTION
Follow-up to #517.

## Problem

#517 made `canView` include every slug in `fl_assistant_post_types_known`. That list exists for a different reason: it lets private types stay browsable in Assistant despite `show_ui => false`. Reusing it for `canView` made "list this type in Assistant" and "offer this type in the cloud library upload picker" the same question, with three side effects:

1. The upload picker gained Block Template, Block Template Part, and Code, none of which belong there. Block templates are scoped to a theme via the `wp_theme` taxonomy, so an imported one arrives bound to the source site's theme slug and is never loaded. Code snippets already have their own first-class `code` library item type.
2. The post detail page rendered a "View" action for all four private types. `url` is `get_permalink()`, which for a non-public, non-publicly-queryable type is a `?post_type=...&p=ID` URL that 404s.
3. The code snippet location rules dropdown started offering Block Template, Block Template Part, and Design System as location targets.

## Fix

Split the two questions.

`canView` now keys off a new `fl_assistant_post_types_library` filter instead of `$known`, so `$known` goes back to meaning "list this type in Assistant" only. The default is `[ 'fl-design-system' ]`, which is the use case #517 was opened for.

A new `hasPublicUrl` carries the real `public || publicly_queryable` test, and the two surfaces that link to the front end now use it instead of `canView`: the post detail View action and the code snippet location rules.

## Also included

`1f37bafe` centers notice content in `.fl-asst-notice`. WordPress rewrote `.components-notice` from a flexbox to a CSS grid with `align-items: start`, which left content hugging the top of the 60px notice bar while the dismiss button stayed centered, and rounded the corners of what Assistant styles as a flat edge-to-edge bar. Unrelated to the post type work, bundled here to avoid a second PR.

## Result

| Type | Content app | Upload picker | View action |
|---|---|---|---|
| Post, Page, and other public types | yes | yes | yes |
| Block Template, Block Template Part, Code | yes | no | no |
| Design System | yes | yes | no |

## Backward compatibility

Both new surfaces are additive: a new filter and a new payload key. `canView` keeps its name and type, and its value for `wp_template`, `wp_template_part`, and `fl_code` returns to what it was for years before dd8bee5d. No renames, no REST shape changes, and no change to the shipped `@beaverbuilder/cloud-ui` bundle, so no npm publish is needed.

## Testing

1. Cloud library, Upload, Post Types. Click **Show All**, since the picker renders only the first five rows. Expect the public types plus Design System, with Block Template, Block Template Part, and Code absent.
2. Open a Design System item from the Content app. "View Design System" should be gone; Edit in Admin and the rest remain.
3. Open a Post. "View Post" should still be present and still work.
4. Code app, open a snippet, Locations. The type dropdown should no longer offer Block Template, Block Template Part, or Design System.

Verified against the live config on a local site: picker types are `post`, `page`, `team`, `product`, `fl-design-system`, `fl-builder-template`, `fl-theme-layout`, and `fl-design-system` reports `hasPublicUrl: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)